### PR TITLE
feat: tools-pdf add pages support for PDF text extraction, metadata and page count

### DIFF
--- a/packages/tools-pdf/src/tools/getTextTool.schema.ts
+++ b/packages/tools-pdf/src/tools/getTextTool.schema.ts
@@ -4,11 +4,24 @@ import { z } from 'zod';
 export const GetTextItemSchema = z.object({
   id: z.string().optional(),
   filePath: z.string().min(1, 'filePath cannot be empty.'),
-  // Add options like page range later if needed
+  // Page selection options
+  pages: z
+    .union([
+      z.array(z.number().int().positive()).optional(),
+      z
+        .object({
+          start: z.number().int().positive(),
+          end: z.number().int().positive(),
+        })
+        .optional(),
+    ])
+    .optional(),
 });
 
 // Main input schema: an array of PDF items
 export const getTextToolInputSchema = z.object({
   items: z.array(GetTextItemSchema).min(1, 'At least one PDF item is required.'),
+  includeMetadata: z.boolean().optional(),
+  includePageCount: z.boolean().optional(),
   // allowOutsideWorkspace is handled by ToolExecuteOptions
 });


### PR DESCRIPTION
# PDF Pagination Enhancement

## Overview
This PR implements pagination support for the PDF text extraction tool. This enhancement allows users to retrieve text content from specific page ranges of PDF documents in a more efficient and controlled manner, with detailed pagination information in the output.

## Features
- Added support for retrieving text content from specific page ranges using either:
  - An array of specific page numbers: `[1, 3, 5]`
  - A page range object: `{ start: 1, end: 10 }`
- Enhanced output structure to include:
  - Consolidated text from all requested pages
  - Individual page texts with their corresponding page numbers
  - Optional metadata extraction when requested
  - Optional page count information when requested

## Technical Implementation
- Enhanced the `extractPdfText` function to support pagination options
- Updated input schema to properly validate and process page range requests
- Improved error handling for pagination-related operations
- Maintained backward compatibility with existing API